### PR TITLE
fix: change of bigest year {prenoms}

### DIFF
--- a/inst/tutorials/01-reshape-data_fr/01-Reshape-Data-fr.Rmd
+++ b/inst/tutorials/01-reshape-data_fr/01-Reshape-Data-fr.Rmd
@@ -641,7 +641,10 @@ prenoms %>%
 
 ### Une meilleure façon de regarder les données
 
-Une meilleure façon d'explorer ce phénomène serait de tracer directement un ratio garçons/filles dans le temps. Pour construire un tel graphique, vous avez d'abord besoin de calculer le ratio garçons/filles pour chaque année de 1900 à 2018 :
+```{r, echo=FALSE}
+year_max <- prenoms %>% summarise(max(year)) %>% pull()
+```
+Une meilleure façon d'explorer ce phénomène serait de tracer directement un ratio garçons/filles dans le temps. Pour construire un tel graphique, vous avez d'abord besoin de calculer le ratio garçons/filles pour chaque année de 1900 à `r year_max` :
 
 $$\text{ratio} = \frac{\text{total garçons (M)}}{\text{total filles (F)}}$$
 

--- a/inst/tutorials/02-isolating_fr/02-isolating-fr.Rmd
+++ b/inst/tutorials/02-isolating_fr/02-isolating-fr.Rmd
@@ -386,7 +386,7 @@ arrange(prenoms, n, prop)
 
 Si vous préférez organiser les lignes dans l'ordre inverse, c'est-à-dire des valeurs _les plus grandes_ aux valeurs _les plus petites_, entourez un nom de colonne avec la fonction `desc()`. `arrange()` réordonnera les lignes des plus grandes valeurs aux plus petites.
 
-Ajoutez un `desc()` au code ci-dessous pour afficher le prénom le plus populaire pour 2018 (la plus grande année du jeu de données) au lieu de 1900 (la plus petite année du jeu de données).
+Ajoutez un `desc()` au code ci-dessous pour afficher le prénom le plus populaire pour la plus grande année du jeu de données au lieu de 1900 (la plus petite année du jeu de données).
 
 ```{r arrange-3, exercise = TRUE, exercise.eval = TRUE}
 arrange(prenoms, year, desc(prop))
@@ -443,7 +443,7 @@ boys_2018
 
 ### Redondance
 
-Le résultat nous montre les prénoms de garçons les plus populaires de 2018 qui est l'année la plus récente disponible dans le jeu de données. Mais jetez un œil au code. Remarquez-vous comment nous recréons `boys_2018` à chaque étape afin que nous ayons quelque chose à passer à l'étape suivante ? 
+Le résultat nous montre les prénoms de garçons les plus populaires de 2018. Mais jetez un œil au code. Remarquez-vous comment nous recréons `boys_2018` à chaque étape afin que nous ayons quelque chose à passer à l'étape suivante ? 
 
 Vous pouvez éviter de créer `boys_2018` à chaque fois. Pour cela, une première stratégie consiste à imbriquer vos fonctions les unes dans les autres. Cependant, cela crée du code difficile à lire :
 

--- a/inst/tutorials/03-deriving_fr/03-deriving-fr.Rmd
+++ b/inst/tutorials/03-deriving_fr/03-deriving-fr.Rmd
@@ -56,8 +56,14 @@ knitr::opts_chunk$set(echo = FALSE)
 
 ## Bienvenue
 
+```{r, echo=FALSE}
+year_max <- prenoms %>% summarise(max(year)) %>% pull()
+```
 
-Dans cette étude de cas, vous allez identifier les prénoms les plus populaires de 1900 à 2018 En faisant cela, vous maîtriserez trois autres fonctions {dplyr} :
+
+Dans cette étude de cas, vous allez identifier les prénoms les plus populaires de 1900 à `r year_max`.
+
+En faisant cela, vous maîtriserez trois autres fonctions {dplyr} :
 
 * `mutate()`, `group_by()`, et `summarise()`, qui permettent d'utiliser vos données pour calculer de nouvelles variables et des statistiques récapitulatives
 
@@ -388,7 +394,7 @@ Deux creux sont observés sur le graphique : le nombre d'enfant nés en France m
 
 ### Popularité basée sur les rangs
 
-Le graphique ci-dessus suggère que notre première définition de la popularité est confondue avec la croissance de la population : les prénoms les plus populaires en 2018 représentent probablement beaucoup plus d'enfants que les prénoms les plus populaires en 1900. Le nombre total d'enfants auxquels on a donné un prénom peut toujours être la meilleure définition de popularité à utiliser, mais il sur-pondérera alors les prénoms qui ont été populaires ces dernières années.
+Le graphique ci-dessus suggère que notre première définition de la popularité est confondue avec la croissance de la population : les prénoms les plus populaires en `r year_max` représentent probablement beaucoup plus d'enfants que les prénoms les plus populaires en 1900. Le nombre total d'enfants auxquels on a donné un prénom peut toujours être la meilleure définition de popularité à utiliser, mais il sur-pondérera alors les prénoms qui ont été populaires ces dernières années.
 
 Il existe également des preuves que notre définition est confondue avec un effet du genre : seulement deux des dix premiers prénoms étaient ceux d'une fille (Jeanne et Marie).
 


### PR DESCRIPTION
tags: fix

Why?
the "bigest" year from prenoms will depend on future updates of {prenoms}

What?
In french lessons:
- stop mentionning a precise year as the "bigest" year in the data in 1 lesson
- compute the biggest year from `prenoms` to be used in data presentation in 2 lessons

Issue #26